### PR TITLE
Criteria aangepast bij Telephonebook opdracht

### DIFF
--- a/week2/opdrachten.html
+++ b/week2/opdrachten.html
@@ -146,7 +146,7 @@
 					<li>Een methode die alle personen uit het telefoonboek gesorteerd op achternaam terug geeft.</li>
 					<li>Een methode die alle personen uit het telefoonboek terug geeft waarvan de voornaam begint met een opgegeven letter. Deze lijst moet ook weer gesorteerd op achternaam zijn.</li>
 					<li>Een methode die alle achternamen van personen uit het telefoonboek terug geeft waarvan de lengte van de achternaam groter is dan een opgegeven waarde. </li>
-					<li>De lijst van achternamen moet gesorteerd op lengte teruggegeven worden waarbij de langste achternaam bovenaan staat en de kortste achternaam onderaan.</li>	
+					<li>De lijst van achternamen moet gesorteerd op lengte teruggegeven worden waarbij de langste achternaam onderaan staat en de kortste achternaam bovenaan.</li>	
 					<li>Een read-only property die aangeeft hoeveel personen er in het telefoonboek zitten.</li>
 				</ul>
 				


### PR DESCRIPTION
Criteria van de methodes aangepast bij de Telephonebook opdracht van week 2.

Bij de opdracht stond dat de methode `SortByLastNameLength` de achternamen gesorteerd van hoog naar laag moet teruggeven, echter test de Unit Test (`Sort_By_Last_Name_Length`) het precies andersom.

Dit kan natuurlijk ook opgelost worden door het aanpassen van de Unit Test.
